### PR TITLE
5 some parameters should be optionnal

### DIFF
--- a/Gravity.GoogleMaps.StaticMapBuilder.Tests/Models/MapStyles/MapStyleTest.cs
+++ b/Gravity.GoogleMaps.StaticMapBuilder.Tests/Models/MapStyles/MapStyleTest.cs
@@ -14,17 +14,21 @@ public class MapStyleTest
         "0x00FF00")]
 
     [InlineData(
-        "feature:road.local|color:0xFF0000",
+        "feature:road.local|color:0xFF00AA",
         "road.local",
         null,
-        "0xFF0000")]
+        "0xFF00AA")]
 
     [InlineData(
-        "element:geometry|color:0xFF0000",
+        "element:geometry|color:0xFF00BB",
         null,
         "geometry",
-        "0xFF0000")]
-
+        "0xFF00BB")]
+    [InlineData(
+        "color:0xFF00EE",
+        null, 
+        null,
+        "0xFF00EE")]
     public void ToString_ProducesExpectedOutput(
         string expected,
         string? featureValue,
@@ -55,7 +59,7 @@ public class MapStyleTest
     public void ToString_WithOnlyStyleRule_ReturnsStyleOnly()
     {
         StyleRule style = new(Color: new HexColor("0xFFCC00"));
-        MapStyle mapStyle = new(style, null, null);
+        MapStyle mapStyle = new(style);
 
         string result = mapStyle.ToString();
 

--- a/Gravity.GoogleMaps.StaticMapBuilder/Models/MapStyles/MapStyle.cs
+++ b/Gravity.GoogleMaps.StaticMapBuilder/Models/MapStyles/MapStyle.cs
@@ -13,8 +13,8 @@
 /// <param name="Element">The element of the feature where the <see cref="StyleRule"/> is applied.</param>
 public record MapStyle(
     StyleRule StyleRule,
-    Feature? Feature,
-    Element? Element)
+    Feature? Feature = null,
+    Element? Element = null)
 {
     /// <inheritdoc />
     public override string ToString()

--- a/Gravity.GoogleMaps.StaticMapBuilder/Models/MarkerGroup.cs
+++ b/Gravity.GoogleMaps.StaticMapBuilder/Models/MarkerGroup.cs
@@ -12,7 +12,7 @@ namespace Gravity.GoogleMaps.StaticMapBuilder.Models;
 /// <param name="anchor">The anchor of the markers.</param>
 /// <param name="iconUrl">The icon url of the markers.</param>
 public class MarkerGroup(
-    MarkerSize size,
+    MarkerSize size = MarkerSize.Default,
     OneOf<StaticMapColor, HexColor>? color = null,
     char? label = null,
     MarkerScale markerScale = MarkerScale.One,
@@ -47,6 +47,7 @@ public class MarkerGroup(
     /// <param name="longitude">The longitude of the new marker in the group.</param>
     public void AddCoordinates(double latitude, double longitude)
     {
+        // TODO : Manage the "Precision beyond the 6 decimal places is ignored"
         _locations.Add($"{latitude.ToString(CultureInfo.InvariantCulture)},{longitude.ToString(CultureInfo.InvariantCulture)}");
     }
     


### PR DESCRIPTION
This pull request introduces several changes to improve the usability and flexibility of the `Gravity.GoogleMaps.StaticMapBuilder` library. Key modifications include adjustments to default parameter values, updates to test cases, and the addition of a TODO comment for future precision handling.

### Updates to default parameter values:

* [`Gravity.GoogleMaps.StaticMapBuilder/Models/MapStyles/MapStyle.cs`](diffhunk://#diff-2d094a186818ffdd9d1774ba5f25f7c3671d52ed1914d988c3e6c441467a94d9L16-R17): Updated the `Feature` and `Element` parameters in the `MapStyle` record to allow default values of `null`, simplifying object creation when these values are not provided.
* [`Gravity.GoogleMaps.StaticMapBuilder/Models/MarkerGroup.cs`](diffhunk://#diff-c4ddfd23e4986b7b7e5b972edbadc4437d09ab695db47958d054b92019771716L15-R15): Set the `size` parameter in the `MarkerGroup` class to default to `MarkerSize.Default`, making it optional during instantiation.

### Test case improvements:

* [`Gravity.GoogleMaps.StaticMapBuilder.Tests/Models/MapStyles/MapStyleTest.cs`](diffhunk://#diff-460378fc5d6a6b43cf8da189c43263432a9831f606a3fb7ca8f976de9f23e3ebL17-R31): Updated several `InlineData` test cases to use new color values, added a new test case for styles with only a color rule, and modified the `ToString_WithOnlyStyleRule_ReturnsStyleOnly` test to reflect the updated `MapStyle` constructor. [[1]](diffhunk://#diff-460378fc5d6a6b43cf8da189c43263432a9831f606a3fb7ca8f976de9f23e3ebL17-R31) [[2]](diffhunk://#diff-460378fc5d6a6b43cf8da189c43263432a9831f606a3fb7ca8f976de9f23e3ebL58-R62)